### PR TITLE
feat: 로그인 시 Jwt토큰 필터에서 로그인 정보 SecurityContextHolder에 저장, 토큰이 쿠키에 존재할 시 로그인정보 찾아오는 APi 구현

### DIFF
--- a/src/main/java/com/example/backend/auth/controller/AuthController.java
+++ b/src/main/java/com/example/backend/auth/controller/AuthController.java
@@ -10,14 +10,12 @@ import com.example.backend.auth.util.CookieUtil;
 import com.example.backend.auth.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 
 @Slf4j
@@ -70,4 +68,5 @@ public class AuthController {
 
     return ResponseEntity.ok().build();
   }
+
 }

--- a/src/main/java/com/example/backend/auth/filter/JwtTokenFilter.java
+++ b/src/main/java/com/example/backend/auth/filter/JwtTokenFilter.java
@@ -111,17 +111,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
     try {
       log.debug("🛡️ 액세스 토큰 검증 중...");
       Member loginMember = authService.getLoginMember(JwtUtil.getUserId(accessToken, SECRET_KEY));
-      UsernamePasswordAuthenticationToken authenticationToken =
-              new UsernamePasswordAuthenticationToken(
-                      AuthDto.builder()
-                              .uniqueId(loginMember.getUniqueId())
-                              .email(loginMember.getEmail())
-                              .build(),
-                      null,
-                      Collections.singletonList(new SimpleGrantedAuthority(loginMember.getRole())));
-
-      authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-      SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+      setUserPasswordAuthenticationToken(request, loginMember);
     } catch (WrongTokenException e) {
       if(refreshToken != null) {
         try {
@@ -133,18 +123,8 @@ public class JwtTokenFilter extends OncePerRequestFilter {
 
           log.info("🔄 사용자 {} 액세스 토큰 리프레시 성공", loginMember.getName());
 
-          UsernamePasswordAuthenticationToken authenticationToken =
-                  new UsernamePasswordAuthenticationToken(
-                          AuthDto.builder()
-                                  .uniqueId(loginMember.getUniqueId())
-                                  .email(loginMember.getEmail())
-                                  .build(),
-                          null,
-                          Collections.singletonList(new SimpleGrantedAuthority(loginMember.getRole())));
-
-          authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-          SecurityContextHolder.getContext().setAuthentication(authenticationToken);
-      } catch (Exception refreshEx) {
+          setUserPasswordAuthenticationToken(request, loginMember);
+        } catch (Exception refreshEx) {
         // 더 상세한 로깅을 포함한 개선된 예외 처리
         log.error("❌ 토큰 리프레시 실패: {}", refreshEx.getMessage());
         throw new DoNotLoginException();
@@ -156,6 +136,22 @@ public class JwtTokenFilter extends OncePerRequestFilter {
     }
     System.out.println("User authenticated successfully.");
     filterChain.doFilter(request, response);
+  }
+
+  private void setUserPasswordAuthenticationToken(HttpServletRequest request, Member loginMember) {
+    UsernamePasswordAuthenticationToken authenticationToken =
+            new UsernamePasswordAuthenticationToken(
+                    AuthDto.builder()
+                            .uniqueId(loginMember.getUniqueId())
+                            .name(loginMember.getName())
+                            .email(loginMember.getEmail())
+                            .level(loginMember.getLevel())
+                            .build(),
+                    null,
+                    Collections.singletonList(new SimpleGrantedAuthority(loginMember.getRole())));
+
+    authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+    SecurityContextHolder.getContext().setAuthentication(authenticationToken);
   }
 
 }

--- a/src/main/java/com/example/backend/member/controller/MemberController.java
+++ b/src/main/java/com/example/backend/member/controller/MemberController.java
@@ -1,10 +1,14 @@
 package com.example.backend.member.controller;
 
+import com.example.backend.auth.dto.AuthDto;
 import com.example.backend.member.DTO.SearchMemberDTO;
 import com.example.backend.member.service.MemberService;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -12,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/member")
 @RequiredArgsConstructor
@@ -43,5 +48,18 @@ public class MemberController {
             System.out.println(searchMemberDTO.getEmail());
         }
         return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<AuthDto> fetchLoginUserData() {
+        log.debug("fetching Logged in UserData...");
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        if (principal instanceof AuthDto) {
+            AuthDto authDto = (AuthDto) principal;
+            return ResponseEntity.ok(authDto);
+        } else {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
     }
 }


### PR DESCRIPTION
JwtTokenFilter: 로그인시, 토큰의 정보를 가져와 SecurityContextHolder에 이메일,권한,이름,학번 저장
MemberController: SecurityContextHolder에 저장된 개인정보를 조회하는 /me api 추가