### PR TITLE
[FEAT]서명요청시 본인이 서명자로 있을 경우 바로 서명이 가능하도록 수정

### DIFF
--- a/src/main/java/com/example/backend/document/controller/DocumentController.java
+++ b/src/main/java/com/example/backend/document/controller/DocumentController.java
@@ -55,7 +55,7 @@ public class DocumentController {
 
     @PostMapping(value = "/full-upload", consumes = {"multipart/form-data"})
     @Transactional
-    public ResponseEntity<String> fullUpload(
+    public  ResponseEntity<Map<String, Object>> fullUpload(
             @RequestParam("file") MultipartFile file,
             @RequestPart("dto") UploadRequestDTO dto
     ) {
@@ -93,11 +93,17 @@ public class DocumentController {
                 signatureRequestService.saveRequestsAndSendMail(document, dto.getSigners(), dto.getPassword(), dto.getMemberName(), dto.getExpirationDateTime());
             }
 
-            return ResponseEntity.ok("문서 업로드 및 서명 요청이 성공적으로 처리되었습니다.");
+            // ✅ 문서 ID 포함한 응답 생성
+            Map<String, Object> response = new HashMap<>();
+            response.put("message", "문서 업로드 및 서명 요청이 성공적으로 처리되었습니다.");
+            response.put("documentId", document.getId());
+            return ResponseEntity.ok(response);
 
         } catch (IllegalArgumentException e) {
             log.warn("사용자 조회 실패: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+            Map<String, Object> errorResponse = new HashMap<>();
+            errorResponse.put("error", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
         } catch (Exception e) {
             log.error("❌ fullUpload 실패", e);
             throw new RuntimeException("fullUpload 처리 중 오류 발생: " + e.getMessage(), e);

--- a/src/main/java/com/example/backend/signature/service/SignatureService.java
+++ b/src/main/java/com/example/backend/signature/service/SignatureService.java
@@ -134,17 +134,13 @@ public class SignatureService {
         Document document = documentRepository.findById(documentId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 문서를 찾을 수 없습니다. ID: " + documentId));
 
-        List<SignatureRequest> signatureRequests = signatureRequestRepository.findByDocumentIdAndSignerEmail(documentId, signerEmail);
+        SignatureRequest signatureRequest = signatureRequestRepository
+                .findByDocumentIdAndSignerEmail(documentId, signerEmail)
+                .orElseThrow(() -> new IllegalArgumentException("해당 문서에 대한 서명 요청이 존재하지 않습니다."));
 
-        if (signatureRequests.isEmpty()) {
-            throw new IllegalArgumentException("해당 문서에 대한 서명 요청이 존재하지 않습니다.");
-        }
-
-        // ✅ 2. 해당 서명 요청을 "완료(1)" 상태로 변경
-        for (SignatureRequest request : signatureRequests) {
-            request.setStatus(1); // 서명 완료 상태
-        }
-        signatureRequestRepository.saveAll(signatureRequests);
+        //2. 서명 상태 변경
+        signatureRequest.setStatus(1); // 완료
+        signatureRequestRepository.save(signatureRequest);
 
         // 📌 3. 해당 문서의 모든 서명 요청이 완료되었는지 확인
         boolean allCompleted = signatureRequestRepository

--- a/src/main/java/com/example/backend/signatureRequest/DTO/TokenRequestDTO.java
+++ b/src/main/java/com/example/backend/signatureRequest/DTO/TokenRequestDTO.java
@@ -1,0 +1,13 @@
+package com.example.backend.signatureRequest.DTO;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class TokenRequestDTO {
+    private Long documentId;
+    private String email;
+
+}
+

--- a/src/main/java/com/example/backend/signatureRequest/controller/SignatureRequestController.java
+++ b/src/main/java/com/example/backend/signatureRequest/controller/SignatureRequestController.java
@@ -10,6 +10,7 @@ import com.example.backend.signatureRequest.DTO.SignatureRequestDTO;
 import com.example.backend.signatureRequest.DTO.SignatureRequestMailDTO;
 import com.example.backend.signatureRequest.DTO.SignerDTO;
 import com.example.backend.auth.controller.request.SignatureValidationRequest;
+import com.example.backend.signatureRequest.DTO.TokenRequestDTO;
 import com.example.backend.signatureRequest.entity.SignatureRequest;
 import com.example.backend.signatureRequest.repository.SignatureRequestRepository;
 import com.example.backend.signatureRequest.service.SignatureRequestService;
@@ -209,5 +210,18 @@ public class SignatureRequestController {
         return ResponseEntity.ok(signers);
     }
 
+    @PostMapping("/token")
+    public ResponseEntity<Map<String, Object>> getTokenForDocumentAndEmail(@RequestBody TokenRequestDTO dto) {
+        try {
+            String token = signatureRequestService.findTokenByDocumentIdAndEmail(dto.getDocumentId(), dto.getEmail());
+            Map<String, Object> response = new HashMap<>();
+            response.put("token", token);
+            return ResponseEntity.ok(response);
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Collections.singletonMap("error", "해당 서명 요청을 찾을 수 없습니다."));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Collections.singletonMap("error", "토큰 요청중 알수 없는 에러가 발생했습니다."));
+        }
+    }
 
 }

--- a/src/main/java/com/example/backend/signatureRequest/repository/SignatureRequestRepository.java
+++ b/src/main/java/com/example/backend/signatureRequest/repository/SignatureRequestRepository.java
@@ -32,7 +32,7 @@ public interface SignatureRequestRepository extends JpaRepository<SignatureReque
 
     Optional<SignatureRequest> findByToken(String token);
 
-    List<SignatureRequest> findByDocumentIdAndSignerEmail(Long documentId, String signerEmail);
+    Optional<SignatureRequest> findByDocumentIdAndSignerEmail(Long documentId, String signerEmail);
 
     @Query("SELECT distinct sr.signerName, sr.signerEmail, sr.status, s.signedAt " +
             "FROM SignatureRequest sr " +

--- a/src/main/java/com/example/backend/signatureRequest/service/SignatureRequestService.java
+++ b/src/main/java/com/example/backend/signatureRequest/service/SignatureRequestService.java
@@ -1,8 +1,10 @@
 package com.example.backend.signatureRequest.service;
 
+import com.example.backend.auth.util.EncryptionUtil;
 import com.example.backend.document.service.DocumentService;
 import com.example.backend.mail.service.MailService;
 import com.example.backend.signature.DTO.SignatureDTO;
+import com.example.backend.signature.repository.SignatureRepository;
 import com.example.backend.signature.service.SignatureService;
 import com.example.backend.signatureRequest.DTO.SignerDTO;
 import com.example.backend.signatureRequest.entity.SignatureRequest;
@@ -16,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -30,6 +33,7 @@ public class SignatureRequestService {
     private final DocumentService documentService;
     private final SignatureRequestRepository signatureRequestRepository;
     private final DocumentRepository documentRepository;
+    private final EncryptionUtil encryptionUtil;
 
     public List<SignatureRequest> createSignatureRequests(Document document, List<SignerDTO> signers, String password, LocalDateTime expiredAt) {
         List<SignatureRequest> requests = signers.stream().map(signer -> {
@@ -159,6 +163,11 @@ public class SignatureRequestService {
         }
     }
 
-
+    public String findTokenByDocumentIdAndEmail(Long documentId, String email) throws Exception {
+        SignatureRequest request = signatureRequestRepository
+                .findByDocumentIdAndSignerEmail(documentId, email)
+                .orElseThrow(() -> new NoSuchElementException("서명 요청 없음"));
+        return encryptionUtil.encryptUUID(request.getToken());
+    }
 
 }


### PR DESCRIPTION
이메일과 문서 아이디로 요청 토큰을 조회하는 API "/token" 추가
- 불필요하게 해당 정보를 불러오는 리포지토리함수가 리스트 형태로 리턴값을 가지고 있던 것을 하나만 가지도록 수정
- 요청 DTO 생성
- 문서 업로드 성공시 문서 ID도 같이 반환하도록 수정